### PR TITLE
fix: Wrap MCP server responses in JSON-RPC 2.0 format

### DIFF
--- a/src/mcp/server.py
+++ b/src/mcp/server.py
@@ -388,15 +388,49 @@ class MCPServer:
         for line in sys.stdin:
             try:
                 request = json.loads(line.strip())
-                response = self.handle_request(request)
+                request_id = request.get("id")
+                result = self.handle_request(request)
+
+                # Wrap response in JSON-RPC 2.0 format
+                if "error" in result and isinstance(result.get("error"), str):
+                    # Convert simple error to JSON-RPC error format
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "error": {
+                            "code": -32600,
+                            "message": result["error"],
+                        },
+                    }
+                else:
+                    response = {
+                        "jsonrpc": "2.0",
+                        "id": request_id,
+                        "result": result,
+                    }
+
                 print(json.dumps(response))
                 sys.stdout.flush()
             except json.JSONDecodeError as e:
-                error_response = {"error": f"Invalid JSON: {str(e)}"}
+                error_response = {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {
+                        "code": -32700,
+                        "message": f"Parse error: {str(e)}",
+                    },
+                }
                 print(json.dumps(error_response))
                 sys.stdout.flush()
             except Exception as e:
-                error_response = {"error": f"Server error: {str(e)}"}
+                error_response = {
+                    "jsonrpc": "2.0",
+                    "id": None,
+                    "error": {
+                        "code": -32603,
+                        "message": f"Internal error: {str(e)}",
+                    },
+                }
                 print(json.dumps(error_response))
                 sys.stdout.flush()
 


### PR DESCRIPTION
The local python MCP server was returning responses directly without the required JSON-RPC 2.0 wrapper. This caused clients to fail with errors like "Missing required fields: jsonrpc, id".

Now all responses are properly wrapped with:
- jsonrpc: "2.0"
- id: request ID
- result: for successful responses
- error: {code, message} for errors

Uses standard JSON-RPC error codes:
- -32700: Parse error
- -32600: Invalid Request
- -32603: Internal error