### PR TITLE
feat: website SEO, M4 landing section, and LLM discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,13 @@ ArbBuilder/
 ├── docs/
 │   └── mcp_tools_spec.md # MCP tools specification
 ├── apps/web/               # Hosted service (Cloudflare Workers + Next.js)
+│   ├── src/app/
+│   │   ├── layout.tsx      # Root layout + SEO meta + JSON-LD structured data
+│   │   ├── page.tsx        # Landing page (M1-M4 feature sections)
+│   │   ├── robots.ts       # robots.txt generation
+│   │   ├── sitemap.ts      # sitemap.xml generation
+│   │   ├── llms.txt/       # LLM discovery endpoint
+│   │   └── playground/     # Interactive tool playground (18 hosted tools)
 │   ├── src/lib/
 │   │   ├── scraper.ts      # Web doc scraping (HTMLRewriter)
 │   │   ├── github.ts       # GitHub repo scraping (Trees/Contents API)

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -15,12 +15,13 @@ const geistMono = Geist_Mono({
 });
 
 export const metadata: Metadata = {
+  metadataBase: new URL("https://arbuilder.app"),
   title: {
-    default: "ARBuilder - AI-Powered Stylus Development",
+    default: "ARBuilder - Accelerate Smart Contract Development on Arbitrum",
     template: "%s | ARBuilder",
   },
   description:
-    "Build Arbitrum Stylus smart contracts with AI-powered tools. Generate code, tests, and get instant answers to your development questions.",
+    "Ship smart contracts and dApps faster with 19 AI-powered MCP tools for Arbitrum. Stylus contracts, cross-chain bridging, full-stack scaffolding, and Orbit L3 deployment — inside Cursor, Claude Code, and VS Code.",
   keywords: [
     "Arbitrum",
     "Stylus",
@@ -30,24 +31,43 @@ export const metadata: Metadata = {
     "Blockchain",
     "AI",
     "Code Generation",
+    "MCP",
+    "Model Context Protocol",
+    "Orbit",
+    "L3",
+    "Cross-Chain",
+    "Bridging",
+    "dApp",
+    "Cursor",
+    "Claude Code",
+    "WASM",
   ],
-  authors: [{ name: "ARBuilder Team" }],
+  authors: [{ name: "Quantum3 Labs" }],
   openGraph: {
-    title: "ARBuilder - AI-Powered Stylus Development",
+    title: "ARBuilder - Accelerate Smart Contract Development on Arbitrum",
     description:
-      "Build Arbitrum Stylus smart contracts with AI-powered tools.",
+      "Ship smart contracts and dApps faster with 19 AI-powered MCP tools. Stylus contracts, bridging, full-stack scaffolding, and Orbit L3 deployment. Free to start.",
     type: "website",
     locale: "en_US",
+    url: "https://arbuilder.app",
+    siteName: "ARBuilder",
   },
   twitter: {
     card: "summary_large_image",
-    title: "ARBuilder - AI-Powered Stylus Development",
+    title: "ARBuilder - Accelerate Smart Contract Development on Arbitrum",
     description:
-      "Build Arbitrum Stylus smart contracts with AI-powered tools.",
+      "Ship smart contracts and dApps faster with 19 AI-powered MCP tools. Stylus contracts, bridging, full-stack scaffolding, and Orbit L3 deployment.",
   },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+    },
+  },
+  alternates: {
+    canonical: "https://arbuilder.app",
   },
 };
 
@@ -67,6 +87,31 @@ export default function RootLayout({
     <html lang="en" className="scroll-smooth">
       <head>
         <link rel="icon" href="/favicon.svg" type="image/svg+xml" />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{
+            __html: JSON.stringify({
+              "@context": "https://schema.org",
+              "@type": "SoftwareApplication",
+              name: "ARBuilder",
+              description:
+                "Accelerate smart contract and dApp development on Arbitrum. 19 AI-powered MCP tools for Stylus contracts, cross-chain bridging, full-stack scaffolding, and Orbit L3 chain deployment.",
+              url: "https://arbuilder.app",
+              applicationCategory: "DeveloperApplication",
+              operatingSystem: "Cross-platform",
+              offers: {
+                "@type": "Offer",
+                price: "0",
+                priceCurrency: "USD",
+              },
+              author: {
+                "@type": "Organization",
+                name: "Quantum3 Labs",
+                url: "https://github.com/Quantum3-Labs",
+              },
+            }),
+          }}
+        />
       </head>
       <body
         className={`${geistSans.variable} ${geistMono.variable} font-sans antialiased min-h-screen bg-white text-gray-900`}

--- a/apps/web/src/app/llms.txt/route.ts
+++ b/apps/web/src/app/llms.txt/route.ts
@@ -1,0 +1,56 @@
+export function GET() {
+  const content = `# ARBuilder
+
+> Accelerate smart contract and dApp development on Arbitrum with 19 AI-powered MCP tools
+
+ARBuilder is an MCP (Model Context Protocol) server that helps developers ship smart contracts and dApps faster on Arbitrum. It works with Cursor, Claude Code, VS Code, and any MCP-compatible IDE.
+
+## Tools
+
+### M1: Stylus Smart Contracts (6 tools)
+- get_stylus_context: RAG retrieval for Arbitrum Stylus docs and code examples
+- generate_stylus_code: Generate Stylus contracts (Rust/WASM) from natural language
+- ask_stylus: Q&A for Stylus development, debugging, concepts
+- generate_tests: Generate unit, integration, and fuzz tests
+- get_workflow: Build/deploy/test workflow guidance
+- validate_stylus_code: Compile-check code via Docker cargo check
+
+### M2: Arbitrum SDK Bridging (3 tools)
+- generate_bridge_code: ETH/ERC20 bridging (L1<>L2, L1->L3, L3->L2)
+- generate_messaging_code: Cross-chain messaging via retryable tickets
+- ask_bridging: Bridging Q&A and patterns
+
+### M3: Full dApp Builder (5 tools)
+- generate_backend: NestJS/Express backend with viem integration
+- generate_frontend: Next.js + wagmi + RainbowKit frontend
+- generate_indexer: The Graph subgraph generation
+- generate_oracle: Chainlink oracle integrations
+- orchestrate_dapp: Full dApp scaffolding coordinator
+
+### M4: Orbit Chain Integration (5 tools)
+- generate_orbit_config: Orbit chain configuration (Rollup, AnyTrust, custom gas tokens)
+- generate_orbit_deployment: Rollup and token bridge deployment
+- generate_validator_setup: Validator, batch poster, and DAC keyset management
+- ask_orbit: Orbit chain Q&A
+- orchestrate_orbit: Full Orbit chain project scaffolding
+
+## Quick Start
+
+Hosted (no setup):
+\`\`\`
+claude mcp add arbbuilder -- npx -y mcp-remote https://arbuilder.app/mcp --header "Authorization: Bearer YOUR_API_KEY"
+\`\`\`
+
+## Links
+- Website: https://arbuilder.app
+- GitHub: https://github.com/Quantum3-Labs/ARBuilder
+- Playground: https://arbuilder.app/playground
+`;
+
+  return new Response(content, {
+    headers: {
+      "Content-Type": "text/plain; charset=utf-8",
+      "Cache-Control": "public, max-age=86400",
+    },
+  });
+}

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -60,17 +60,18 @@ export default async function Home() {
         <div className="max-w-4xl mx-auto text-center animate-fade-in-up">
           <div className="inline-flex items-center gap-2 px-4 py-2 bg-blue-50 rounded-full text-blue-700 text-sm font-medium mb-6">
             <span className="w-2 h-2 bg-blue-500 rounded-full animate-pulse" />
-            AI-Powered Development
+            Ship Smart Contracts Faster
           </div>
           <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-gray-900 mb-6 leading-tight">
-            Build on Arbitrum
+            Accelerate Blockchain Dev
             <br />
-            <span className="gradient-text">with AI-Powered Tools</span>
+            <span className="gradient-text">on Arbitrum with AI</span>
           </h1>
           <p className="text-lg sm:text-xl text-gray-600 mb-10 max-w-2xl mx-auto leading-relaxed">
-            ARBuilder provides AI-powered tools for Stylus smart contracts,
-            cross-chain bridging, full-stack dApp generation, and L1/L2/L3
-            messaging. Connect your IDE and start building in minutes.
+            Ship smart contracts and dApps faster. ARBuilder gives you 19
+            AI-powered MCP tools that handle Stylus contracts, cross-chain
+            bridging, full-stack scaffolding, and Orbit L3 deployment — right
+            inside Cursor, Claude Code, or VS Code.
           </p>
           <div className="flex flex-col sm:flex-row justify-center gap-4">
             <Link
@@ -358,6 +359,84 @@ export default async function Home() {
               </div>
             ))}
           </div>
+          {/* Orbit Chain Integration */}
+          <div className="text-center mb-12 mt-16">
+            <div className="inline-flex items-center gap-2 px-3 py-1 bg-cyan-50 rounded-full text-cyan-700 text-sm font-medium mb-4">
+              Orbit L3 Chains
+            </div>
+            <h2 className="text-3xl sm:text-4xl font-bold text-gray-900 mb-4">
+              Orbit Chain Deployment
+            </h2>
+            <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+              Deploy and manage custom Orbit L3 chains with Rollup and AnyTrust support
+            </p>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+            {[
+              {
+                icon: (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.066 2.573c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.573 1.066c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.066-2.573c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z" />
+                ),
+                iconBg: "bg-cyan-100",
+                iconColor: "text-cyan-600",
+                title: "Chain Configuration",
+                description: "Configure Orbit chains with prepareChainConfig, AnyTrust DACs, and custom gas tokens.",
+              },
+              {
+                icon: (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 11H5m14 0a2 2 0 012 2v6a2 2 0 01-2 2H5a2 2 0 01-2-2v-6a2 2 0 012-2m14 0V9a2 2 0 00-2-2M5 11V9a2 2 0 012-2m0 0V5a2 2 0 012-2h6a2 2 0 012 2v2M7 7h10" />
+                ),
+                iconBg: "bg-sky-100",
+                iconColor: "text-sky-600",
+                title: "Rollup Deployment",
+                description: "Deploy rollups and token bridges with createRollup and createTokenBridge via @arbitrum/orbit-sdk.",
+              },
+              {
+                icon: (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+                ),
+                iconBg: "bg-blue-100",
+                iconColor: "text-blue-600",
+                title: "Validator Setup",
+                description: "Manage validators, batch posters, and AnyTrust DAC keysets for chain operations.",
+              },
+              {
+                icon: (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8.228 9c.549-1.165 2.03-2 3.772-2 2.21 0 4 1.343 4 3 0 1.4-1.278 2.575-3.006 2.907-.542.104-.994.54-.994 1.093m0 3h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+                ),
+                iconBg: "bg-indigo-100",
+                iconColor: "text-indigo-600",
+                title: "Orbit Q&A",
+                description: "Get answers about Orbit deployment, configuration, and chain operations.",
+              },
+              {
+                icon: (
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 7l-8-4-8 4m16 0l-8 4m8-4v10l-8 4m0-10L4 7m8 4v10M4 7v10l8 4" />
+                ),
+                iconBg: "bg-cyan-100",
+                iconColor: "text-cyan-600",
+                title: "Full Orchestration",
+                description: "Scaffold complete Orbit chain projects with config, deployment, bridges, and node setup.",
+              },
+            ].map((feature, index) => (
+              <div
+                key={feature.title}
+                className={`bg-white p-6 rounded-2xl border border-gray-100 shadow-sm card-hover opacity-0 animate-fade-in stagger-${index + 1}`}
+              >
+                <div className={`w-12 h-12 ${feature.iconBg} rounded-xl flex items-center justify-center mb-4`}>
+                  <svg className={`w-6 h-6 ${feature.iconColor}`} fill="none" viewBox="0 0 24 24" stroke="currentColor">
+                    {feature.icon}
+                  </svg>
+                </div>
+                <h3 className="text-lg font-semibold text-gray-900 mb-2">
+                  {feature.title}
+                </h3>
+                <p className="text-gray-600 leading-relaxed">
+                  {feature.description}
+                </p>
+              </div>
+            ))}
+          </div>
         </div>
       </section>
 
@@ -430,8 +509,8 @@ export default async function Home() {
             Free to Start
           </h2>
           <p className="text-xl text-blue-100 mb-10 max-w-2xl mx-auto">
-            Our free tier includes everything you need to get started with
-            Stylus development.
+            Our free tier includes all 19 tools — Stylus contracts, SDK
+            bridging, dApp scaffolding, and Orbit chain deployment.
           </p>
           <div className="bg-white/10 backdrop-blur-sm rounded-2xl p-8 border border-white/20">
             <div className="grid grid-cols-2 md:grid-cols-4 gap-6 mb-8">

--- a/apps/web/src/app/robots.ts
+++ b/apps/web/src/app/robots.ts
@@ -1,0 +1,14 @@
+import { MetadataRoute } from "next";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/admin", "/dashboard"],
+      },
+    ],
+    sitemap: "https://arbuilder.app/sitemap.xml",
+  };
+}

--- a/apps/web/src/app/sitemap.ts
+++ b/apps/web/src/app/sitemap.ts
@@ -1,0 +1,32 @@
+import { MetadataRoute } from "next";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const baseUrl = "https://arbuilder.app";
+
+  return [
+    {
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 1,
+    },
+    {
+      url: `${baseUrl}/playground`,
+      lastModified: new Date(),
+      changeFrequency: "weekly",
+      priority: 0.9,
+    },
+    {
+      url: `${baseUrl}/transparency`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+    },
+    {
+      url: `${baseUrl}/login`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 0.5,
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- Add **M4 Orbit Chain Integration** section to landing page (was missing — only M1-M3 were shown)
- Update hero messaging to "Accelerate Blockchain Dev on Arbitrum with AI" with "Ship Smart Contracts Faster" badge
- Broaden SEO meta (title, description, keywords, OG, Twitter) to cover all 19 tools across 4 milestones
- Add `metadataBase`, canonical URL, and JSON-LD structured data (SoftwareApplication schema)
- Add `robots.ts` and `sitemap.ts` for search engine crawlability
- Add `llms.txt` route for LLM/AI search engine discovery
- Update free tier copy to mention all tool categories
- Update README repo structure with new `apps/web/src/app/` files

## Test plan
- [ ] Verify landing page renders M4 Orbit section with 5 cards
- [ ] Check `https://arbuilder.app/robots.txt` returns valid robots.txt
- [ ] Check `https://arbuilder.app/sitemap.xml` returns valid sitemap
- [ ] Check `https://arbuilder.app/llms.txt` returns tool descriptions
- [ ] Validate OG meta tags with https://www.opengraph.xyz/
- [ ] Test JSON-LD with https://search.google.com/test/rich-results