### PR TITLE
fix: resolve CI failures (TS5107 + missing toml dep)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -18,10 +18,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -55,10 +55,10 @@ jobs:
     if: ${{ github.event.inputs.refresh_rag == 'true' || github.event_name == 'push' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -81,7 +81,7 @@ jobs:
         run: python -m src.preprocessing.processor
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 

--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -33,9 +33,9 @@ jobs:
     outputs:
       has_update: ${{ steps.check.outputs.has_update }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -71,7 +71,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: sdk-monitor-report
           path: reports/sdk_monitor.json
@@ -87,9 +87,9 @@ jobs:
     outputs:
       critical_count: ${{ steps.check.outputs.critical_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -120,7 +120,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: health-check-report
           path: reports/health_check.json
@@ -133,9 +133,9 @@ jobs:
       github.event.inputs.task == 'discover' ||
       github.event.inputs.task == 'all'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -149,7 +149,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: discovery-report
           path: reports/discovery.json
@@ -164,7 +164,7 @@ jobs:
       github.event_name == 'schedule' &&
       (needs.sdk-monitor.outputs.has_update == 'true' || needs.health-check.outputs.critical_count != '0')
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const date = new Date().toISOString().split('T')[0];
@@ -196,9 +196,9 @@ jobs:
       (needs.sdk-monitor.outputs.has_update == 'true') ||
       (github.event.inputs.task == 'reverify')
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -220,7 +220,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: reverification-report
@@ -232,9 +232,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.task == 'remediate'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -262,7 +262,7 @@ jobs:
           fi
 
       - name: Upload report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: always()
         with:
           name: remediation-report
@@ -277,9 +277,9 @@ jobs:
       github.event.inputs.task == 'all' ||
       github.event_name == 'schedule'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -15,9 +15,9 @@ jobs:
     name: TypeScript Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -35,11 +35,11 @@ jobs:
     name: Python Linting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -66,9 +66,9 @@ jobs:
     name: Python Tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/.github/workflows/refresh-rag.yml
+++ b/.github/workflows/refresh-rag.yml
@@ -22,10 +22,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true
 
       - name: Upload raw data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: raw-data
           path: |
@@ -70,16 +70,16 @@ jobs:
     needs: scrape
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download raw data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: raw-data
           path: data/raw/
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'
@@ -91,7 +91,7 @@ jobs:
         run: python -m src.preprocessing.processor
 
       - name: Upload processed data
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: processed-data
           path: |
@@ -105,16 +105,16 @@ jobs:
     needs: process
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download processed data
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: processed-data
           path: ./
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -133,7 +133,7 @@ jobs:
           fi
 
       - name: Upload migration state
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: rag-state
           path: .rag-state/
@@ -146,16 +146,16 @@ jobs:
     if: ${{ github.event.inputs.skip_validation != 'true' }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rag-state
           path: .rag-state/
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -178,7 +178,7 @@ jobs:
     if: always()
     steps:
       - name: Download state
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: rag-state
           path: .rag-state/

--- a/.github/workflows/release-chunks.yml
+++ b/.github/workflows/release-chunks.yml
@@ -23,10 +23,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: 'pip'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "httpx>=0.27.0",
     "tenacity>=8.0.0",
     "rank-bm25>=0.2.2",
+    "toml>=0.10.0",
 ]
 
 [project.optional-dependencies]

--- a/tests/mcp_tools/test_orbit_tools.py
+++ b/tests/mcp_tools/test_orbit_tools.py
@@ -1339,8 +1339,8 @@ class TestTypeScriptCompilation:
         tsconfig = {
             "compilerOptions": {
                 "target": "ES2020",
-                "module": "ES2020",
-                "moduleResolution": "node16",
+                "module": "Node16",
+                "moduleResolution": "Node16",
                 "skipLibCheck": True,
                 "noEmit": True,
                 "strict": False,

--- a/tests/mcp_tools/test_orbit_tools.py
+++ b/tests/mcp_tools/test_orbit_tools.py
@@ -1340,7 +1340,7 @@ class TestTypeScriptCompilation:
             "compilerOptions": {
                 "target": "ES2020",
                 "module": "ES2020",
-                "moduleResolution": "node",
+                "moduleResolution": "node16",
                 "skipLibCheck": True,
                 "noEmit": True,
                 "strict": False,
@@ -1390,6 +1390,7 @@ class TestTypeScriptCompilation:
                 and "TS2792" not in line  # Cannot find module (type-only)
                 and "TS2591" not in line  # Cannot find name 'process' (needs @types/node)
                 and "TS6305" not in line  # Output file not specified
+                and "TS5107" not in line  # Deprecated moduleResolution option
             ]
             assert not real_errors, f"TypeScript syntax errors in {filename}:\n" + "\n".join(
                 real_errors
@@ -1419,6 +1420,7 @@ class TestTypeScriptCompilation:
                 and "TS2792" not in line
                 and "TS2591" not in line
                 and "TS6305" not in line
+                and "TS5107" not in line  # Deprecated moduleResolution option
             ]
             assert not real_errors, f"TypeScript syntax errors in {filename}:\n" + "\n".join(
                 real_errors
@@ -1450,6 +1452,7 @@ class TestTypeScriptCompilation:
                 and "TS2792" not in line
                 and "TS2591" not in line
                 and "TS6305" not in line
+                and "TS5107" not in line  # Deprecated moduleResolution option
             ]
             assert not real_errors, f"TypeScript syntax errors in {filename}:\n" + "\n".join(
                 real_errors
@@ -1482,6 +1485,7 @@ class TestTypeScriptCompilation:
                 and "TS2792" not in line
                 and "TS2591" not in line
                 and "TS6305" not in line
+                and "TS5107" not in line  # Deprecated moduleResolution option
             ]
             if real_errors:
                 failures.append(f"{filename}:\n  " + "\n  ".join(real_errors))


### PR DESCRIPTION
## Summary
- **QA Checks failure**: TypeScript 7.0 deprecated `moduleResolution=node10` (TS5107). Added TS5107 to error filters in all 4 orbit TS compilation tests, and updated the test tsconfig to use `module=Node16` + `moduleResolution=Node16`.
- **Source Maintenance failure**: `maintain_sources.py` imports `toml` via `scraper/version_extractor.py`, but `toml` was not listed in `pyproject.toml` dependencies. Added `toml>=0.10.0`.
- **Node.js 20 deprecation**: Bumped all GitHub Actions to latest versions with Node.js 24 support:
  - `actions/checkout` v4 → v6
  - `actions/setup-python` v5 → v6
  - `actions/setup-node` v4 → v6
  - `actions/upload-artifact` v4 → v7
  - `actions/download-artifact` v4 → v8
  - `actions/github-script` v7 → v9

## Test plan
- [x] `TestTypeScriptCompilation` (all 4 tests) passes locally
- [x] CI QA Checks pass on this PR
- [ ] CI Source Maintenance no longer fails on `ModuleNotFoundError: No module named 'toml'`
- [ ] No more Node.js 20 deprecation warnings in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)