### PR TITLE
fix(ci): grant issues:write and bump reverify timeout in maintenance workflow

### DIFF
--- a/.github/workflows/maintenance.yml
+++ b/.github/workflows/maintenance.yml
@@ -159,6 +159,9 @@ jobs:
     name: Create Maintenance Issue
     runs-on: ubuntu-latest
     needs: [sdk-monitor, health-check]
+    permissions:
+      contents: read
+      issues: write
     if: >-
       always() &&
       github.event_name == 'schedule' &&
@@ -215,7 +218,7 @@ jobs:
 
       - name: Run full verification
         run: python scripts/verify_source.py --all --steps 1,2,4 --output reports/reverification.json
-        timeout-minutes: 30
+        timeout-minutes: 60
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Summary

The scheduled `Source Maintenance` workflow has been failing on main. Two distinct issues, both fixed here:

- **`create-issue` job** failed with `Resource not accessible by integration` calling `github.rest.issues.create()`. The workflow had no `permissions:` block, so the default `GITHUB_TOKEN` couldn't open issues. Scoped `issues: write` narrowly to the `create-issue` job.
- **`reverify` job** hit its 30-minute step timeout while running `verify_source.py --all`. Bumped `timeout-minutes` to 60. If that's still not enough, the next step is splitting `--all` into a matrix per-source.

Reference: failed run https://github.com/Quantum3-Labs/ARBuilder/actions/runs/24984921448

## Test plan

- [ ] Trigger via `workflow_dispatch` with `task: reverify` to confirm full verification finishes within 60 min
- [ ] Trigger via `workflow_dispatch` with `task: all` (or wait for next Monday cron) to confirm `create-issue` can open an issue when needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)