### PR TITLE
feat: per-key CORS origin allowlist for browser embedding

### DIFF
--- a/apps/web/migrations/0006_api_key_origins.sql
+++ b/apps/web/migrations/0006_api_key_origins.sql
@@ -1,0 +1,7 @@
+-- Per-key CORS allowlist for browser-originated requests.
+-- NULL  = unrestricted (server-to-server use, default).
+-- '[]'  = locked (no browser may use this key).
+-- '["https://docs.example.com", ...]'  = browser may use this key only from these origins.
+--
+-- Server-to-server requests (no Origin header) ignore this column entirely.
+ALTER TABLE api_keys ADD COLUMN allowed_origins TEXT;

--- a/apps/web/src/app/api/keys/[id]/route.ts
+++ b/apps/web/src/app/api/keys/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { auth } from "@/auth";
 import { revokeApiKey } from "@/lib/apiKeys";
+import { validateOriginList } from "@/lib/cors";
 
 
 // DELETE /api/keys/[id] - Revoke an API key
@@ -34,5 +35,76 @@ export async function DELETE(
       { error: "Internal server error" },
       { status: 500 }
     );
+  }
+}
+
+/**
+ * PATCH /api/keys/[id] — owner can update mutable fields on their key.
+ * Body: { name?: string | null, allowedOrigins?: string[] | null }
+ *   - allowedOrigins:
+ *       null   → unrestricted (server-to-server)
+ *       []     → locked (no browser may use this key)
+ *       [...]  → only listed origins may use this key from a browser
+ *       ["*"]  → any browser origin
+ */
+export async function PATCH(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const { id } = await params;
+    const { env } = getCloudflareContext();
+
+    const body = (await request.json().catch(() => ({}))) as {
+      name?: string | null;
+      allowedOrigins?: string[] | null;
+    };
+
+    const owns = await env.DB
+      .prepare(`SELECT id FROM api_keys WHERE id = ? AND user_id = ? AND revoked_at IS NULL`)
+      .bind(id, session.user.id)
+      .first();
+    if (!owns) {
+      return NextResponse.json({ error: "API key not found" }, { status: 404 });
+    }
+
+    const updates: string[] = [];
+    const values: unknown[] = [];
+    if (body.name !== undefined) {
+      updates.push("name = ?");
+      values.push(body.name === null ? null : String(body.name).trim() || null);
+    }
+    if (body.allowedOrigins !== undefined) {
+      let serialised: string | null;
+      if (body.allowedOrigins === null) {
+        serialised = null;
+      } else {
+        try {
+          serialised = JSON.stringify(validateOriginList(body.allowedOrigins));
+        } catch (e) {
+          return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+        }
+      }
+      updates.push("allowed_origins = ?");
+      values.push(serialised);
+    }
+    if (updates.length === 0) {
+      return NextResponse.json({ error: "No fields to update" }, { status: 400 });
+    }
+
+    values.push(id);
+    await env.DB
+      .prepare(`UPDATE api_keys SET ${updates.join(", ")} WHERE id = ?`)
+      .bind(...values)
+      .run();
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.error("PATCH /api/keys/[id] failed:", e);
+    return NextResponse.json({ error: (e as Error).message || String(e) }, { status: 500 });
   }
 }

--- a/apps/web/src/app/api/v1/chat/completions/route.ts
+++ b/apps/web/src/app/api/v1/chat/completions/route.ts
@@ -13,6 +13,7 @@ import { validateRequest } from "@/lib/auth/validateRequest";
 import { runAgentNonStreaming, runAgentStreaming } from "@/lib/chat/agent";
 import { encodeSSEChunk, encodeSSEDone, encodeSSEError } from "@/lib/chat/streaming";
 import { enforceRateLimit, rateLimitHeaders, subjectFor } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 import type {
   ChatCompletionRequest,
   ChatCompletionResponse,
@@ -68,6 +69,14 @@ export async function POST(request: NextRequest) {
   const start = Date.now();
   const { env } = getCloudflareContext();
 
+  // Permissive CORS for pre-auth errors — we don't know the key yet, so we
+  // reflect Origin to keep the browser happy while still returning the real
+  // status code and body.
+  const reqOrigin = request.headers.get("Origin");
+  const preAuthCors: Record<string, string> = reqOrigin
+    ? { "Access-Control-Allow-Origin": reqOrigin, "Access-Control-Allow-Credentials": "true", Vary: "Origin" }
+    : { Vary: "Origin" };
+
   // Auth — same flow as /api/v1/tools/* and /mcp.
   const auth = await validateRequest(request, env.DB, env.AUTH_SECRET);
   if (!auth.success) {
@@ -75,8 +84,14 @@ export async function POST(request: NextRequest) {
       "Authentication required. Pass a valid `Authorization: Bearer arb_...` header.",
       "invalid_api_key",
       401,
+      undefined,
+      preAuthCors,
     );
   }
+
+  // CORS allowlist enforcement (browser-only).
+  const cors = evaluateCors(request, auth.allowedOrigins);
+  if (!cors.ok) return cors.response;
 
   // Rate limit — per-key for arb_ keys, per-user for session auth, bypass for admin.
   const subj = subjectFor(auth);
@@ -92,27 +107,31 @@ export async function POST(request: NextRequest) {
         "rate_limit_exceeded",
         429,
         undefined,
-        rlHeaders,
+        { ...rlHeaders, ...cors.headers },
       );
     }
   }
+  // Merge CORS headers into the rate-limit header bag for the success path.
+  rlHeaders = { ...rlHeaders, ...cors.headers };
 
   // Parse body.
   let body: ChatCompletionRequest;
   try {
     body = (await request.json()) as ChatCompletionRequest;
   } catch {
-    return errorResponse("Invalid JSON body.", "invalid_request_error", 400);
+    return errorResponse("Invalid JSON body.", "invalid_request_error", 400, undefined, rlHeaders);
   }
   if (!Array.isArray(body.messages) || body.messages.length === 0) {
     return errorResponse(
       "Missing required field 'messages' (must be a non-empty array).",
       "invalid_request_error",
       400,
+      undefined,
+      rlHeaders,
     );
   }
   if (!env.OPENROUTER_API_KEY) {
-    return errorResponse("OpenRouter not configured on this server.", "internal_error", 500);
+    return errorResponse("OpenRouter not configured on this server.", "internal_error", 500, undefined, rlHeaders);
   }
 
   const toolEnv: ToolEnv = {
@@ -215,18 +234,10 @@ export async function POST(request: NextRequest) {
     if (apiKeyId) {
       await logChatUsage(env.DB, apiKeyId, [], 0, Date.now() - start, false, msg);
     }
-    return errorResponse(msg, "internal_error", 500);
+    return errorResponse(msg, "internal_error", 500, undefined, rlHeaders);
   }
 }
 
-// CORS preflight.
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/ask-bridging/route.ts
+++ b/apps/web/src/app/api/v1/tools/ask-bridging/route.ts
@@ -3,6 +3,7 @@ import { askBridging, type AskBridgingInput } from "@/lib/tools/askBridging";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     if (!env.OPENROUTER_API_KEY) {
       return NextResponse.json(
@@ -39,7 +42,7 @@ export async function POST(request: NextRequest) {
       }
     );
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in askBridging:", message, error);
@@ -48,4 +51,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/ask-orbit/route.ts
+++ b/apps/web/src/app/api/v1/tools/ask-orbit/route.ts
@@ -3,6 +3,7 @@ import { askOrbit, type AskOrbitInput } from "@/lib/tools/askOrbit";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     if (!env.OPENROUTER_API_KEY) {
       return NextResponse.json(
@@ -38,7 +41,7 @@ export async function POST(request: NextRequest) {
       }
     );
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in askOrbit:", message, error);
@@ -47,4 +50,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/ask/route.ts
+++ b/apps/web/src/app/api/v1/tools/ask/route.ts
@@ -3,6 +3,7 @@ import { askStylus, type AskStylusInput } from "@/lib/tools/askStylus";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 
 export async function POST(request: NextRequest) {
@@ -15,6 +16,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     // Check for OpenRouter API key
     if (!env.OPENROUTER_API_KEY) {
@@ -46,7 +49,7 @@ export async function POST(request: NextRequest) {
       }
     );
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in askStylus:", message, error);
@@ -55,4 +58,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/backend/route.ts
+++ b/apps/web/src/app/api/v1/tools/backend/route.ts
@@ -3,6 +3,7 @@ import { generateBackend } from "@/lib/tools/generateBackend";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -33,7 +36,7 @@ export async function POST(request: NextRequest) {
       features: body.features,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateBackend:", message, error);
@@ -42,4 +45,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/bridge/route.ts
+++ b/apps/web/src/app/api/v1/tools/bridge/route.ts
@@ -3,6 +3,7 @@ import { generateBridgeCode } from "@/lib/tools/generateBridgeCode";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       bridgeType?: string;
@@ -33,7 +36,7 @@ export async function POST(request: NextRequest) {
       destinationAddress: body.destinationAddress,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateBridgeCode:", message, error);
@@ -42,4 +45,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/context/route.ts
+++ b/apps/web/src/app/api/v1/tools/context/route.ts
@@ -3,6 +3,7 @@ import { getStylusContext, type GetStylusContextInput } from "@/lib/tools/getSty
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 
 export async function POST(request: NextRequest) {
@@ -15,6 +16,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     // Parse request body
     const body = (await request.json()) as GetStylusContextInput;
@@ -34,7 +37,7 @@ export async function POST(request: NextRequest) {
       rerank: body.rerank ?? true,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in getStylusContext:", message, error);
@@ -43,4 +46,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/frontend/route.ts
+++ b/apps/web/src/app/api/v1/tools/frontend/route.ts
@@ -3,6 +3,7 @@ import { generateFrontend } from "@/lib/tools/generateFrontend";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -33,7 +36,7 @@ export async function POST(request: NextRequest) {
       template: body.template as "base" | "dashboard" | "token" | undefined,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateFrontend:", message, error);
@@ -42,4 +45,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/generate/route.ts
+++ b/apps/web/src/app/api/v1/tools/generate/route.ts
@@ -3,6 +3,7 @@ import { generateStylusCode, type GenerateStylusCodeInput } from "@/lib/tools/ge
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 
 export async function POST(request: NextRequest) {
@@ -15,6 +16,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     // Check for OpenRouter API key
     if (!env.OPENROUTER_API_KEY) {
@@ -48,7 +51,7 @@ export async function POST(request: NextRequest) {
       }
     );
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateStylusCode:", message, error);
@@ -57,4 +60,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/indexer/route.ts
+++ b/apps/web/src/app/api/v1/tools/indexer/route.ts
@@ -3,6 +3,7 @@ import { generateIndexer } from "@/lib/tools/generateIndexer";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       contractAddress?: string;
@@ -35,7 +38,7 @@ export async function POST(request: NextRequest) {
       network: body.network,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateIndexer:", message, error);
@@ -44,4 +47,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/messaging/route.ts
+++ b/apps/web/src/app/api/v1/tools/messaging/route.ts
@@ -3,6 +3,7 @@ import { generateMessagingCode } from "@/lib/tools/generateMessagingCode";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       messageType?: string;
@@ -29,7 +32,7 @@ export async function POST(request: NextRequest) {
       includeExample: body.includeExample,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateMessagingCode:", message, error);
@@ -38,4 +41,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/oracle/route.ts
+++ b/apps/web/src/app/api/v1/tools/oracle/route.ts
@@ -3,6 +3,7 @@ import { generateOracle } from "@/lib/tools/generateOracle";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       oracleType?: string;
@@ -31,7 +34,7 @@ export async function POST(request: NextRequest) {
       feeds: body.feeds,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateOracle:", message, error);
@@ -40,4 +43,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/orbit-config/route.ts
+++ b/apps/web/src/app/api/v1/tools/orbit-config/route.ts
@@ -3,6 +3,7 @@ import { generateOrbitConfig } from "@/lib/tools/generateOrbitConfig";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -37,7 +40,7 @@ export async function POST(request: NextRequest) {
       parentChain: body.parentChain as Parameters<typeof generateOrbitConfig>[0]["parentChain"],
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateOrbitConfig:", message, error);
@@ -46,4 +49,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/orbit-deploy/route.ts
+++ b/apps/web/src/app/api/v1/tools/orbit-deploy/route.ts
@@ -3,6 +3,7 @@ import { generateOrbitDeployment } from "@/lib/tools/generateOrbitDeployment";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -45,7 +48,7 @@ export async function POST(request: NextRequest) {
       rollupAddress: body.rollupAddress,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateOrbitDeployment:", message, error);
@@ -54,4 +57,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/orbit-validator/route.ts
+++ b/apps/web/src/app/api/v1/tools/orbit-validator/route.ts
@@ -3,6 +3,7 @@ import { generateValidatorSetup } from "@/lib/tools/generateValidatorSetup";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -39,7 +42,7 @@ export async function POST(request: NextRequest) {
       parentChain: body.parentChain as Parameters<typeof generateValidatorSetup>[0]["parentChain"],
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateValidatorSetup:", message, error);
@@ -48,4 +51,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/orchestrate-orbit/route.ts
+++ b/apps/web/src/app/api/v1/tools/orchestrate-orbit/route.ts
@@ -3,6 +3,7 @@ import { orchestrateOrbit } from "@/lib/tools/orchestrateOrbit";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -41,7 +44,7 @@ export async function POST(request: NextRequest) {
       batchPosters: body.batchPosters,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in orchestrateOrbit:", message, error);
@@ -50,4 +53,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/orchestrate/route.ts
+++ b/apps/web/src/app/api/v1/tools/orchestrate/route.ts
@@ -3,6 +3,7 @@ import { orchestrateDapp } from "@/lib/tools/orchestrateDapp";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function POST(request: NextRequest) {
   try {
@@ -11,6 +12,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const body = (await request.json()) as {
       prompt?: string;
@@ -35,7 +38,7 @@ export async function POST(request: NextRequest) {
       contractAbi: body.contractAbi,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in orchestrateDapp:", message, error);
@@ -44,4 +47,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/tests/route.ts
+++ b/apps/web/src/app/api/v1/tools/tests/route.ts
@@ -3,6 +3,7 @@ import { generateTests, type GenerateTestsInput } from "@/lib/tools/generateTest
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 
 export async function POST(request: NextRequest) {
@@ -15,6 +16,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     // Check for OpenRouter API key
     if (!env.OPENROUTER_API_KEY) {
@@ -42,7 +45,7 @@ export async function POST(request: NextRequest) {
       coverageFocus: body.coverageFocus,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in generateTests:", message, error);
@@ -51,4 +54,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/tools/workflow/route.ts
+++ b/apps/web/src/app/api/v1/tools/workflow/route.ts
@@ -3,6 +3,7 @@ import { getWorkflow, type GetWorkflowInput } from "@/lib/tools/getWorkflow";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { checkToolRateLimit } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 
 export async function POST(request: NextRequest) {
@@ -15,6 +16,8 @@ export async function POST(request: NextRequest) {
     if (!auth.success) return auth.response;
     const rl = await checkToolRateLimit(env.KV, auth);
     if ("response" in rl) return rl.response;
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     // Parse request body
     const body = (await request.json()) as GetWorkflowInput;
@@ -40,7 +43,7 @@ export async function POST(request: NextRequest) {
       includeTroubleshooting: body.includeTroubleshooting ?? true,
     });
 
-    return NextResponse.json(result, { headers: rl.headers });
+    return NextResponse.json(result, { headers: { ...rl.headers, ...cors.headers } });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     console.error("Error in getWorkflow:", message, error);
@@ -49,4 +52,8 @@ export async function POST(request: NextRequest) {
       { status: 500 }
     );
   }
+}
+
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }

--- a/apps/web/src/app/api/v1/usage/route.ts
+++ b/apps/web/src/app/api/v1/usage/route.ts
@@ -16,6 +16,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { validateRequest } from "@/lib/auth/validateRequest";
 import { peekUsage, subjectFor } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse } from "@/lib/cors";
 
 export async function GET(request: NextRequest) {
   try {
@@ -23,6 +24,9 @@ export async function GET(request: NextRequest) {
 
     const auth = await validateRequest(request, env.DB, env.AUTH_SECRET);
     if (!auth.success) return auth.response;
+
+    const cors = evaluateCors(request, auth.allowedOrigins);
+    if (!cors.ok) return cors.response;
 
     const subj = subjectFor(auth);
     const tier = subj?.tier ?? (auth.isAdmin ? "unlimited" : "free");
@@ -37,7 +41,7 @@ export async function GET(request: NextRequest) {
         chat: { minute: placeholder.minute, day: placeholder.day },
         tool: { minute: placeholderTool.minute, day: placeholderTool.day },
         recent: null,
-      });
+      }, { headers: cors.headers });
     }
 
     const [chatUsage, toolUsage] = await Promise.all([
@@ -78,7 +82,7 @@ export async function GET(request: NextRequest) {
       chat: { minute: chatUsage.minute, day: chatUsage.day },
       tool: { minute: toolUsage.minute, day: toolUsage.day },
       recent,
-    });
+    }, { headers: cors.headers });
   } catch (e) {
     console.error("usage endpoint failed:", e);
     return NextResponse.json(
@@ -88,13 +92,6 @@ export async function GET(request: NextRequest) {
   }
 }
 
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "GET, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "GET, OPTIONS");
 }

--- a/apps/web/src/app/dashboard/keys/page.tsx
+++ b/apps/web/src/app/dashboard/keys/page.tsx
@@ -9,6 +9,8 @@ interface ApiKey {
   createdAt: string;
   lastUsedAt: string | null;
   rateLimitTier?: string;
+  /** Raw JSON string from API; parsed in render. */
+  allowedOrigins?: string | null;
 }
 
 interface WindowState {
@@ -311,10 +313,15 @@ export default function ApiKeysPage() {
                     <span>Last used: {formatDate(key.lastUsedAt)}</span>
                   </div>
                   {usage[key.id] && <UsageWidget u={usage[key.id]} />}
+                  <OriginsEditor
+                    keyId={key.id}
+                    raw={key.allowedOrigins}
+                    onSaved={fetchKeys}
+                  />
                 </div>
                 <button
                   onClick={() => revokeKey(key.id)}
-                  className="text-red-600 hover:text-red-700 hover:bg-red-50 text-sm font-medium px-3 py-1.5 rounded-lg transition-colors flex-shrink-0"
+                  className="text-red-600 hover:text-red-700 hover:bg-red-50 text-sm font-medium px-3 py-1.5 rounded-lg transition-colors flex-shrink-0 self-start"
                 >
                   Revoke
                 </button>
@@ -370,6 +377,134 @@ function Bar({ window: w, used, limit }: { window: "min" | "day"; used: number; 
       <span className="w-16 text-right tabular-nums text-gray-600">
         {used} / {limit}
       </span>
+    </div>
+  );
+}
+
+function parseOrigins(raw: string | null | undefined): string[] | null {
+  if (raw == null) return null;
+  try {
+    const v = JSON.parse(raw);
+    return Array.isArray(v) ? v.filter((s) => typeof s === "string") : null;
+  } catch {
+    return null;
+  }
+}
+
+function OriginsEditor({
+  keyId,
+  raw,
+  onSaved,
+}: {
+  keyId: string;
+  raw: string | null | undefined;
+  onSaved: () => void;
+}) {
+  const initial = parseOrigins(raw);
+  const [editing, setEditing] = useState(false);
+  const [text, setText] = useState((initial ?? []).join("\n"));
+  const [saving, setSaving] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+
+  const restricted = initial !== null;
+  const origins = initial ?? [];
+
+  async function save(allowedOrigins: string[] | null) {
+    setSaving(true);
+    setErr(null);
+    try {
+      const res = await fetch(`/api/keys/${keyId}`, {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ allowedOrigins }),
+      });
+      const data = (await res.json().catch(() => ({}))) as { error?: string };
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setEditing(false);
+      onSaved();
+    } catch (e) {
+      setErr((e as Error).message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!editing) {
+    return (
+      <div className="mt-3 text-xs flex flex-wrap items-center gap-2">
+        <span className="font-medium text-gray-600">Allowed origins:</span>
+        {!restricted ? (
+          <span className="text-gray-500 italic">Unrestricted (server-to-server only)</span>
+        ) : origins.length === 0 ? (
+          <span className="text-orange-600">Locked — no browser may use this key</span>
+        ) : (
+          origins.map((o) => (
+            <code key={o} className="px-2 py-0.5 bg-blue-50 text-blue-700 rounded font-mono">
+              {o}
+            </code>
+          ))
+        )}
+        <button
+          onClick={() => {
+            setText((initial ?? []).join("\n"));
+            setEditing(true);
+          }}
+          className="text-blue-600 hover:text-blue-700 underline"
+        >
+          Edit
+        </button>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3 text-xs space-y-2">
+      <div className="font-medium text-gray-600">Allowed origins (one per line, or `*` for any):</div>
+      <textarea
+        value={text}
+        onChange={(e) => setText(e.target.value)}
+        rows={3}
+        placeholder="https://docs.example.com&#10;https://example.com"
+        className="w-full px-2 py-1.5 text-xs font-mono border border-gray-200 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500"
+      />
+      <p className="text-gray-500">
+        Empty list = locked (no browser allowed). Use{" "}
+        <button
+          type="button"
+          onClick={() => save(null)}
+          className="underline text-blue-600 hover:text-blue-700"
+          disabled={saving}
+        >
+          unrestricted
+        </button>{" "}
+        for server-to-server keys (default). CORS allowlist applies only to browser requests; server callers without an Origin header are never blocked.
+      </p>
+      {err && <p className="text-red-600">{err}</p>}
+      <div className="flex gap-2">
+        <button
+          onClick={() => {
+            const list = text
+              .split(/\s+/)
+              .map((s) => s.trim())
+              .filter(Boolean);
+            save(list);
+          }}
+          disabled={saving}
+          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {saving ? "Saving…" : "Save"}
+        </button>
+        <button
+          onClick={() => {
+            setEditing(false);
+            setErr(null);
+          }}
+          disabled={saving}
+          className="px-3 py-1 border border-gray-200 rounded hover:bg-gray-50"
+        >
+          Cancel
+        </button>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/app/mcp/route.ts
+++ b/apps/web/src/app/mcp/route.ts
@@ -9,6 +9,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { runTool, type ToolEnv, type ToolResult } from "@/lib/tools/dispatch";
 import { enforceRateLimit, rateLimitHeaders } from "@/lib/rateLimit";
+import { evaluateCors, preflightResponse, parseAllowedOrigins } from "@/lib/cors";
 
 // MCP Protocol Types
 interface JsonRpcRequest {
@@ -634,7 +635,7 @@ const SERVER_INFO = {
 async function validateApiKey(
   request: NextRequest,
   db: D1Database
-): Promise<{ valid: boolean; keyId?: string; userId?: string; tier?: string; error?: string }> {
+): Promise<{ valid: boolean; keyId?: string; userId?: string; tier?: string; allowedOrigins?: string[] | null; error?: string }> {
   const authHeader = request.headers.get("Authorization");
   if (!authHeader?.startsWith("Bearer ")) {
     return { valid: false, error: "Missing or invalid Authorization header" };
@@ -655,10 +656,11 @@ async function validateApiKey(
   // Look up the key
   const keyRecord = await db
     .prepare(
-      `SELECT id, user_id, rate_limit_tier FROM api_keys WHERE key_hash = ? AND revoked_at IS NULL`
+      `SELECT id, user_id, rate_limit_tier, allowed_origins
+       FROM api_keys WHERE key_hash = ? AND revoked_at IS NULL`
     )
     .bind(keyHash)
-    .first<{ id: string; user_id: string; rate_limit_tier: string | null }>();
+    .first<{ id: string; user_id: string; rate_limit_tier: string | null; allowed_origins: string | null }>();
 
   if (!keyRecord) {
     return { valid: false, error: "Invalid or revoked API key" };
@@ -675,6 +677,7 @@ async function validateApiKey(
     keyId: keyRecord.id,
     userId: keyRecord.user_id,
     tier: keyRecord.rate_limit_tier ?? "free",
+    allowedOrigins: parseAllowedOrigins(keyRecord.allowed_origins),
   };
 }
 
@@ -906,6 +909,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // CORS allowlist enforcement (browser-only — server-to-server has no Origin header).
+    const cors = evaluateCors(request, authResult.allowedOrigins);
+    if (!cors.ok) return cors.response;
+
     // Parse request body
     const body = await request.json();
 
@@ -920,22 +927,20 @@ export async function POST(request: NextRequest) {
 
     // Handle single request or batch
     if (Array.isArray(body)) {
-      // Batch request
       const responses = await Promise.all(
         body.map((req: JsonRpcRequest) =>
           processRequest(req, envObj, authResult.keyId, tier)
         )
       );
-      return NextResponse.json(responses);
+      return NextResponse.json(responses, { headers: cors.headers });
     } else {
-      // Single request
       const response = await processRequest(
         body as JsonRpcRequest,
         envObj,
         authResult.keyId,
         tier
       );
-      return NextResponse.json(response);
+      return NextResponse.json(response, { headers: cors.headers });
     }
   } catch (error) {
     console.error("MCP endpoint error:", error);
@@ -953,16 +958,8 @@ export async function POST(request: NextRequest) {
   }
 }
 
-// Handle OPTIONS for CORS
-export async function OPTIONS() {
-  return new NextResponse(null, {
-    status: 204,
-    headers: {
-      "Access-Control-Allow-Origin": "*",
-      "Access-Control-Allow-Methods": "POST, OPTIONS",
-      "Access-Control-Allow-Headers": "Content-Type, Authorization",
-    },
-  });
+export async function OPTIONS(request: NextRequest) {
+  return preflightResponse(request, "POST, OPTIONS");
 }
 
 // Handle GET for health check

--- a/apps/web/src/lib/apiKeys.ts
+++ b/apps/web/src/lib/apiKeys.ts
@@ -14,6 +14,8 @@ export interface ApiKey {
   lastUsedAt: string | null;
   revokedAt: string | null;
   rateLimitTier?: string;
+  /** JSON-serialised string from D1; parse on the client. null = unrestricted. */
+  allowedOrigins?: string | null;
 }
 
 export interface ApiKeyWithSecret extends ApiKey {
@@ -100,7 +102,8 @@ export async function listApiKeys(
     .prepare(
       `SELECT id, user_id as userId, key_prefix as keyPrefix, name,
               created_at as createdAt, last_used_at as lastUsedAt, revoked_at as revokedAt,
-              rate_limit_tier as rateLimitTier
+              rate_limit_tier as rateLimitTier,
+              allowed_origins as allowedOrigins
        FROM api_keys
        WHERE user_id = ? AND revoked_at IS NULL
        ORDER BY created_at DESC`

--- a/apps/web/src/lib/auth/validateRequest.ts
+++ b/apps/web/src/lib/auth/validateRequest.ts
@@ -10,6 +10,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { hashApiKey } from "@/lib/apiKeys";
 import { verifyJWT } from "@/lib/jwt";
+import { parseAllowedOrigins } from "@/lib/cors";
 
 export interface AuthResult {
   success: true;
@@ -18,6 +19,8 @@ export interface AuthResult {
   isAdmin: boolean;
   /** Rate limit tier; only set for API-key auth. Session auth uses 'free' implicitly. */
   rateLimitTier?: string;
+  /** CORS allowlist; only set for API-key auth. null = unrestricted. */
+  allowedOrigins?: string[] | null;
 }
 
 export interface AuthError {
@@ -60,11 +63,13 @@ export async function validateRequest(
 
       const result = await db
         .prepare(
-          `SELECT id, user_id as userId, rate_limit_tier as rateLimitTier FROM api_keys
+          `SELECT id, user_id as userId, rate_limit_tier as rateLimitTier,
+                  allowed_origins as allowedOrigins
+           FROM api_keys
            WHERE key_hash = ? AND revoked_at IS NULL`
         )
         .bind(keyHash)
-        .first<{ id: string; userId: string; rateLimitTier: string | null }>();
+        .first<{ id: string; userId: string; rateLimitTier: string | null; allowedOrigins: string | null }>();
 
       if (result) {
         // Update last used timestamp
@@ -79,6 +84,7 @@ export async function validateRequest(
           keyId: result.id,
           isAdmin: false,
           rateLimitTier: result.rateLimitTier ?? "free",
+          allowedOrigins: parseAllowedOrigins(result.allowedOrigins),
         };
       }
 

--- a/apps/web/src/lib/cors.ts
+++ b/apps/web/src/lib/cors.ts
@@ -1,0 +1,149 @@
+/**
+ * CORS handling shared by every authenticated API route.
+ *
+ * Two layers:
+ *   1. Preflight (OPTIONS) — permissive: we don't know which API key the
+ *      caller will use, so we allow any origin to ask the question. Browsers
+ *      will only proceed to the real request if the actual response also
+ *      passes CORS.
+ *   2. Actual request — enforced against the API key's `allowed_origins`
+ *      column. If the Origin header is set and doesn't match, we 403.
+ *      Server-to-server callers (no Origin header) bypass entirely; the
+ *      column is purely a browser-protection mechanism.
+ *
+ * Responses always include `Vary: Origin` so caches don't serve a response
+ * built for one origin to a request from another.
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+
+/**
+ * Decide what `Access-Control-Allow-Origin` to send and whether the request
+ * is allowed. Call this after auth, before doing any work.
+ *
+ * Returns:
+ *   - { ok: true, headers }  — attach `headers` to the response
+ *   - { ok: false, response } — the request must be rejected (403 with
+ *     CORS body so the browser surfaces a useful error)
+ */
+export function evaluateCors(
+  request: NextRequest,
+  allowedOrigins: string[] | null | undefined,
+): { ok: true; headers: Record<string, string> } | { ok: false; response: NextResponse } {
+  const origin = request.headers.get("Origin");
+
+  // No Origin → server-to-server, allowlist doesn't apply.
+  if (!origin) {
+    return { ok: true, headers: { Vary: "Origin" } };
+  }
+
+  // No restriction set on the key → reflect the origin so it works in browsers
+  // without exposing `*` to credentialed flows.
+  if (allowedOrigins == null) {
+    return { ok: true, headers: corsAllowHeaders(origin) };
+  }
+
+  // Explicit "any" wildcard.
+  if (allowedOrigins.includes("*")) {
+    return { ok: true, headers: corsAllowHeaders(origin) };
+  }
+
+  // Locked or non-matching.
+  if (!allowedOrigins.includes(origin)) {
+    const body = {
+      error: `Origin '${origin}' is not in this API key's allowlist.`,
+      type: "origin_not_allowed",
+      allowedOrigins,
+    };
+    const response = new NextResponse(JSON.stringify(body), {
+      status: 403,
+      headers: { "Content-Type": "application/json", Vary: "Origin" },
+    });
+    return { ok: false, response };
+  }
+
+  return { ok: true, headers: corsAllowHeaders(origin) };
+}
+
+function corsAllowHeaders(origin: string): Record<string, string> {
+  return {
+    "Access-Control-Allow-Origin": origin,
+    "Access-Control-Allow-Credentials": "true",
+    "Access-Control-Expose-Headers":
+      "X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-RateLimit-Tier, " +
+      "X-RateLimit-Limit-Minute, X-RateLimit-Remaining-Minute, X-RateLimit-Reset-Minute, " +
+      "X-RateLimit-Limit-Day, X-RateLimit-Remaining-Day, X-RateLimit-Reset-Day, Retry-After",
+    Vary: "Origin",
+  };
+}
+
+/**
+ * Standardised OPTIONS preflight. Permissive by design — browsers send
+ * preflights without Authorization, so we can't validate against a key's
+ * allowlist here. Reflects the request's Origin so credentialed mode works.
+ */
+export function preflightResponse(request: NextRequest, methods = "POST, OPTIONS"): NextResponse {
+  const origin = request.headers.get("Origin") ?? "*";
+  const requestedHeaders = request.headers.get("Access-Control-Request-Headers")
+    ?? "Content-Type, Authorization, X-Admin-Secret";
+  return new NextResponse(null, {
+    status: 204,
+    headers: {
+      "Access-Control-Allow-Origin": origin,
+      "Access-Control-Allow-Credentials": "true",
+      "Access-Control-Allow-Methods": methods,
+      "Access-Control-Allow-Headers": requestedHeaders,
+      "Access-Control-Max-Age": "86400",
+      Vary: "Origin, Access-Control-Request-Headers",
+    },
+  });
+}
+
+/**
+ * Parse the JSON-array column. Tolerant of legacy NULL or malformed values.
+ */
+export function parseAllowedOrigins(raw: string | null | undefined): string[] | null {
+  if (raw == null) return null;
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed) && parsed.every((v) => typeof v === "string")) return parsed;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Validate origin strings provided by users (e.g., via PATCH /api/keys/[id]).
+ * Accepts full URLs with scheme + host (no path/query/fragment), or "*".
+ * Returns the normalised list, or throws with a helpful message.
+ */
+export function validateOriginList(origins: unknown): string[] {
+  if (!Array.isArray(origins)) throw new Error("allowedOrigins must be an array of origin strings");
+  const out: string[] = [];
+  for (const raw of origins) {
+    if (typeof raw !== "string") throw new Error("allowedOrigins entries must be strings");
+    const v = raw.trim();
+    if (!v) continue;
+    if (v === "*") {
+      out.push("*");
+      continue;
+    }
+    let url: URL;
+    try {
+      url = new URL(v);
+    } catch {
+      throw new Error(`Invalid origin '${v}' — must be a full URL (e.g., 'https://docs.example.com') or '*'`);
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:") {
+      throw new Error(`Origin '${v}' must use http or https`);
+    }
+    if (url.pathname !== "/" && url.pathname !== "") {
+      throw new Error(`Origin '${v}' must not include a path`);
+    }
+    // Canonical form: scheme://host[:port]
+    out.push(`${url.protocol}//${url.host}`);
+  }
+  // De-dupe.
+  return Array.from(new Set(out));
+}


### PR DESCRIPTION
## Summary

Lets a key be safely embedded in a public widget. Stacks on top of #34 (rate-limits) — base is `feat/rate-limits` so the diff stays clean.

## Why

A partner is building a chat widget on a GitHub Pages docs site that hits `/api/v1/chat/completions`. Their static page can't keep an API key secret. Without origin restrictions, anyone scraping the page could lift the key. With this change, the key is bound to specific origins server-side: the browser still has to send the key, but the worker rejects it from any origin not on the allowlist (and the missing ACAO on a 403 means hostile pages can't even read the response).

## API model

| `allowed_origins` value | Meaning |
|---|---|
| `null` (default) | unrestricted — server-to-server use, existing behavior |
| `[]` | locked, no browser may use this key |
| `["https://docs.example.com"]` | only this origin may use it from a browser |
| `["*"]` | any browser origin |

Server-to-server callers (no `Origin` header) ignore the column entirely, so existing CLI / cron / SDK use is unaffected.

## What's new

- **Migration** `0006_api_key_origins.sql` — `ALTER TABLE api_keys ADD COLUMN allowed_origins TEXT`
- **Library** `apps/web/src/lib/cors.ts` — `evaluateCors`, `preflightResponse`, `validateOriginList`, `parseAllowedOrigins`
- **Auth** `validateRequest` + MCP `validateApiKey` carry `allowedOrigins` through
- **Routes** chat, `/api/v1/usage`, every `/api/v1/tools/*`, and `/mcp`:
  - 403 `origin_not_allowed` if Origin is set and not on the allowlist
  - Reflect Origin in `Access-Control-Allow-Origin`, set `Vary: Origin`, expose all rate-limit headers via `Access-Control-Expose-Headers`
  - Standardised OPTIONS via `preflightResponse()` reflecting the requested headers
- **PATCH** `/api/keys/[id]` accepts `{ name?, allowedOrigins? }` (owner-scoped)
- **UI** `/dashboard/keys` adds an "Allowed origins" editor per key with chip-style display, edit-in-place textarea, "unrestricted" shortcut, validation errors surfaced inline
- `listApiKeys` returns `allowed_origins` so the UI renders current state

## Live verification

- Migration applied to remote D1 `arbbuilder`
- Worker deployed (version `b25cf685-0941-4f96-a160-22cd805ec8f6`)
- Verified end-to-end against the partner's key (`ethcluj`) which is now bound to `https://stylus-developers-guild.github.io`:

```
preflight from allowed origin   → 204, ACAO matches, Vary: Origin
POST from allowed origin        → 200, ACAO matches, expose-headers present
POST from disallowed origin     → 403 (no ACAO — browser blocks it)
```

## Test plan

- [ ] `cd apps/web && npm test` → 20/20 pass
- [ ] `npx tsc --noEmit` clean
- [ ] Edit an existing key on `/dashboard/keys`, add `https://example.com`, save, fetch with that Origin → 200 with reflected ACAO
- [ ] Same key, fetch with another Origin → 403 `origin_not_allowed`
- [ ] Server-side curl with no Origin header → 200 (allowlist ignored)
- [ ] OPTIONS preflight from any origin → 204 reflecting requested headers
- [ ] Switch back to "unrestricted" → calls from any origin succeed again

🤖 Generated with [Claude Code](https://claude.com/claude-code)